### PR TITLE
Fix MySQL issues during fixture loading

### DIFF
--- a/threadedcomments/fixtures/simple_tree.json
+++ b/threadedcomments/fixtures/simple_tree.json
@@ -1,67 +1,4 @@
-[
-  {
-    "pk": 1, 
-    "model": "threadedcomments.threadedcomment", 
-    "fields": {
-      "tree_path": "0000000001", 
-      "last_child": 4, 
-      "parent": null
-    }
-  }, 
-  {
-    "pk": 2, 
-    "model": "threadedcomments.threadedcomment", 
-    "fields": {
-      "tree_path": "0000000001/0000000002", 
-      "last_child": 5, 
-      "parent": 1
-    }
-  }, 
-  {
-    "pk": 3, 
-    "model": "threadedcomments.threadedcomment", 
-    "fields": {
-      "tree_path": "0000000001/0000000002/0000000003", 
-      "last_child": null, 
-      "parent": 2
-    }
-  }, 
-  {
-    "pk": 5, 
-    "model": "threadedcomments.threadedcomment", 
-    "fields": {
-      "tree_path": "0000000001/0000000002/0000000005", 
-      "last_child": null, 
-      "parent": 2
-    }
-  }, 
-  {
-    "pk": 4, 
-    "model": "threadedcomments.threadedcomment", 
-    "fields": {
-      "tree_path": "0000000001/0000000004", 
-      "last_child": 6, 
-      "parent": 1
-    }
-  }, 
-  {
-    "pk": 6, 
-    "model": "threadedcomments.threadedcomment", 
-    "fields": {
-      "tree_path": "0000000001/0000000004/0000000006", 
-      "last_child": null, 
-      "parent": 4
-    }
-  }, 
-  {
-    "pk": 7, 
-    "model": "threadedcomments.threadedcomment", 
-    "fields": {
-      "tree_path": "0000000007", 
-      "last_child": null, 
-      "parent": null
-    }
-  }, 
+[ 
   {
     "pk": 1, 
     "model": "comments.comment", 
@@ -186,6 +123,69 @@
       "is_public": true, 
       "user_name": "", 
       "user_email": ""
+    }
+  },
+  {
+    "pk": 1, 
+    "model": "threadedcomments.threadedcomment", 
+    "fields": {
+      "tree_path": "0000000001", 
+      "last_child": null, 
+      "parent": null
+    }
+  }, 
+  {
+    "pk": 2, 
+    "model": "threadedcomments.threadedcomment", 
+    "fields": {
+      "tree_path": "0000000001/0000000002", 
+      "last_child": null, 
+      "parent": 1
+    }
+  }, 
+  {
+    "pk": 3, 
+    "model": "threadedcomments.threadedcomment", 
+    "fields": {
+      "tree_path": "0000000001/0000000002/0000000003", 
+      "last_child": null, 
+      "parent": 2
+    }
+  }, 
+  {
+    "pk": 5, 
+    "model": "threadedcomments.threadedcomment", 
+    "fields": {
+      "tree_path": "0000000001/0000000002/0000000005", 
+      "last_child": null, 
+      "parent": 2
+    }
+  }, 
+  {
+    "pk": 4, 
+    "model": "threadedcomments.threadedcomment", 
+    "fields": {
+      "tree_path": "0000000001/0000000004", 
+      "last_child": null, 
+      "parent": 1
+    }
+  }, 
+  {
+    "pk": 6, 
+    "model": "threadedcomments.threadedcomment", 
+    "fields": {
+      "tree_path": "0000000001/0000000004/0000000006", 
+      "last_child": null, 
+      "parent": 4
+    }
+  }, 
+  {
+    "pk": 7, 
+    "model": "threadedcomments.threadedcomment", 
+    "fields": {
+      "tree_path": "0000000007", 
+      "last_child": null, 
+      "parent": null
     }
   }
 ]

--- a/threadedcomments/tests.py
+++ b/threadedcomments/tests.py
@@ -118,6 +118,13 @@ class HierarchyTest(TransactionTestCase):
         </li>
     </ul>
     ''')
+    
+    def setUp(self):
+        # Set last_child here instead of in fixtures to prevent foreign key
+        # restraint failure
+        comments.get_model().objects.filter(pk=1).update(last_child=4)
+        comments.get_model().objects.filter(pk=2).update(last_child=5)
+        comments.get_model().objects.filter(pk=4).update(last_child=6)
 
     def test_root_path_returns_empty_for_root_comments(self):
         c = comments.get_model().objects.get(pk=7)


### PR DESCRIPTION
I just installed django-threadedcomments into a project I'm working on but had some issues when I ran tests. In a nutshell, fixtures were failing to load because of foreign key restraint failures, e.g.:

```
IntegrityError: (1452, 'Cannot add or update a child row: a foreign key constraint fails (`test_myproject`.`threadedcomments_comment`, CONSTRAINT `comment_ptr_id_refs_id_fa2e61cf` FOREIGN KEY (`comment_ptr_id`) REFERENCES `django_comments` (`id`))')
```

I guess it's possible these fixtures load correctly on other backends? (I imagine this might be why it hasn't been caught until now.) But I had to make two changes to get the fixtures to load properly and for the tests in HierarchyTest to work:
- Invert the order of the comments and threaded comments in simple_tree.json.
- Set all values of last_child in simple_tree.json to null, and then update the values in a setUp() method of HierarchyTest.

The common thread in the issues is that if you attempt to add a row with an ID that references a row that has not yet been created, it fails. These fixes resolve this and tests run.

Anyhow, I'm submitting the changes I needed to make to get tests to run as a pull request. Hopefully you'll find this of use. Thanks
