### PR TITLE
Trying to sort out the version numbering

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,13 @@
 from sys import version_info
-from setuptools import setup, find_packages
+from setuptools import setup
 
 kwargs = {
     'name': 'django-threadedcomments',
-    'version': '0.9',
+    'version': '0.5.4',
     'description': 'A simple yet flexible threaded commenting system.',
     'author': 'Eric Florenzano',
     'author_email': 'floguy@gmail.com',
-    'url': 'http://code.google.com/p/django-threadedcomments/',
+    'url': 'https://github.com/HonzaKral/django-threadedcomments/',
     'keywords': 'django,pinax,comments',
     'license': 'BSD',
     'packages': [


### PR DESCRIPTION
Only tagged version on GitHub was 0.5.2, whereas there was a 0.5.3 on
the PyPi which was ahead of this tagged version, but not very close to
the current HEAD (25b282359409ef672ed9264c91d30ff969f05a96). So I'm
setting this as the 0.5.4 'release' to try and avoid confusion.
