### PR TITLE
Don't delete all of the comment's ancestors with it

### DIFF
--- a/threadedcomments/models.py
+++ b/threadedcomments/models.py
@@ -11,7 +11,7 @@ class ThreadedComment(Comment):
     title = models.TextField(_('Title'), blank=True)
     parent = models.ForeignKey('self', null=True, blank=True, default=None,
         related_name='children', verbose_name=_('Parent'))
-    last_child = models.ForeignKey('self', null=True, blank=True,
+    last_child = models.ForeignKey('self', null=True, blank=True, on_delete=models.SET_NULL,
         verbose_name=_('Last child'))
     tree_path = models.TextField(_('Tree path'), editable=False,
         db_index=True)

--- a/threadedcomments/tests.py
+++ b/threadedcomments/tests.py
@@ -182,6 +182,14 @@ class HierarchyTest(TransactionTestCase):
         comment = Comment.objects.get(pk=1)
         self.assertEqual(comment.last_child, new_child_comment)
 
+    def test_last_child_doesnt_delete_parent(self):
+        Comment = comments.get_model()
+        comment = Comment.objects.get(pk=1)
+        new_child_comment = Comment(comment="Comment 9", site_id=1, content_type_id=7, object_pk=1, parent_id=comment.id)
+        new_child_comment.save()
+        new_child_comment.delete()
+        comment = Comment.objects.get(pk=1)
+
 # Templatetags tests
 ##############################################################################
 


### PR DESCRIPTION
When you try to delete a leaf comment, the deletion cascade to every comment that will point to it via the 'last_child' FK
