### PR TITLE
threaded comment porting on mysql

### DIFF
--- a/threadedcomments/management/commands/migrate_threaded_comments.py
+++ b/threadedcomments/management/commands/migrate_threaded_comments.py
@@ -100,7 +100,7 @@ class Command(NoArgsCommand):
                 site=site,
             )
 
-            tc.save(skip_rtee_path=True)
+            tc.save(skip_tree_path=True)
 
         for comment in ThreadedComment.objects.all():
             path = [str(comment.id).zfill(PATH_DIGITS)]


### PR DESCRIPTION
I did few quick changes to get this to run on mysql with innodb. There were two main problems, innodb does ref integrity checking after each insert, meaning just wrapping it in a transaction is not enough to keep from doing some sort of dependancy resolution, and then secondly you cant safely assume that the auto incramenting primary keys are going to start from zero.  

Not the cleanest, but it worked for me. If making one script that would work in either mysql or postgres is required, then perhaps some people with test db's would be willing to help test?
