### PR TITLE
fix threaded comments html

### DIFF
--- a/examples/core/templates/comments/core/list.html
+++ b/examples/core/templates/comments/core/list.html
@@ -5,8 +5,12 @@
 </div>
 
 <div class="comments">
-    {% for comment in comment_list|fill_tree|annotate_tree %}{% ifchanged comment.parent_id %}{% else %}</li>{% endifchanged %}{% if not comment.open and not comment.close %}</li>{% endif %}{% if comment.open %}
-    <ul>{% endif %}
+    {% for comment in comment_list|fill_tree|annotate_tree %}
+        {% if comment.open %}
+            <ul>
+        {% else %}
+            </li>
+        {% endif %}
         <li class="comment_li" id="c{{ comment.id }}">{# c## is used by the absolute URL of the Comment model, so keep that as it is. #}
             <div class="comment">
                 <div class="comment_info">

--- a/threadedcomments/templates/comments/list.html
+++ b/threadedcomments/templates/comments/list.html
@@ -4,8 +4,12 @@
 {% endcomment %}
 {% load threadedcomments_tags %}
 <div id="comments">
-    {% for comment in comment_list|fill_tree|annotate_tree %}{% ifchanged comment.parent_id %}{% else %}</li>{% endifchanged %}{% if not comment.open and not comment.close %}</li>{% endif %}{% if comment.open %}
-    <ul>{% endif %}
+    {% for comment in comment_list|fill_tree|annotate_tree %}
+        {% if comment.open %}
+            <ul>
+        {% else %}
+            </li>
+        {% endif %}
         <li id="c{{ comment.id }}">{# c## is used by the absolute URL of the Comment model, so keep that as it is. #}
             <dl class="comment">
                 <dt>

--- a/threadedcomments/templates/sample_tree.html
+++ b/threadedcomments/templates/sample_tree.html
@@ -2,16 +2,10 @@
 
 {% for comment in comment_list|fill_tree|annotate_tree %}
 
-{% ifchanged comment.parent_id %}{% else %}
-    </li>
-{% endifchanged %}
-
-{% if not comment.open and not comment.close %}
-    </li>
-{% endif %}
-    
 {% if comment.open %}
     <ul>
+{% else %}
+    </li>
 {% endif %}
 
 <li{% if comment.last %} class="last"{% endif %}>


### PR DESCRIPTION
This fixes issue #53 for me.

I changed this:
```
{% ifchanged comment.parent_id %}{% else %}
    </li>
{% endifchanged %}

{% if not comment.open and not comment.close %}
    </li>
{% endif %}
    
{% if comment.open %}
    <ul>
{% endif %}
```
to this:
```
{% if comment.open %}
    <ul>
{% else %}
    </li>
{% endif %}
```
I'm not sure what the reason was for the more complex logic before, but simplifying this has worked in every case I have tested so far.