### PR TITLE
Added compability with Django==1.7

### DIFF
--- a/examples/core/templates/core/home.html
+++ b/examples/core/templates/core/home.html
@@ -12,7 +12,7 @@
                     <p class="title">{{ message.title }}</p>
 
                     <p class="text">{{ message.text }}</p>
-                    <a href="{% url message_detail id=message.id %}">{{ comment_count }} Comments</a>
+                    <a href="{% url 'message_detail' id=message.id %}">{{ comment_count }} Comments</a>
                 </div>
             </li>
         {% endfor %}

--- a/examples/example/urls.py
+++ b/examples/example/urls.py
@@ -1,13 +1,16 @@
-from django.conf.urls.defaults import *
+from django.conf.urls import *
 from django.contrib import admin
 
 # Enable the admin
 admin.autodiscover()
 
-urlpatterns = patterns('',
+urlpatterns = patterns(
+    '',
     url(r'^admin/', include(admin.site.urls)),
-    url(r'^comments/', include('django.contrib.comments.urls')),
+    url(r'^comments/', include(
+        'django.contrib.comments.urls')),
 
     url(r'^$', 'core.views.home', name='homepage'),
-    url(r'^message/(?P<id>.+)$', 'core.views.message', name='message_detail'),
+    url(r'^message/(?P<id>.+)$',
+        'core.views.message', name='message_detail'),
 )

--- a/threadedcomments/forms.py
+++ b/threadedcomments/forms.py
@@ -5,19 +5,20 @@ from django.utils.translation import ugettext_lazy as _
 
 from threadedcomments.models import ThreadedComment
 
+
 class ThreadedCommentForm(CommentForm):
     parent = forms.IntegerField(required=False, widget=forms.HiddenInput)
 
     def __init__(self, target_object, parent=None, data=None, initial=None):
-        self.base_fields.insert(
-            self.base_fields.keyOrder.index('comment'), 'title',
-            forms.CharField(label=_('Title'), required=False, max_length=getattr(settings, 'COMMENTS_TITLE_MAX_LENGTH', 255))
-        )
+        self.base_fields["title"] = forms.CharField(
+            label=_('Title'), required=False, max_length=getattr(settings, 'COMMENTS_TITLE_MAX_LENGTH', 255))
+
         self.parent = parent
         if initial is None:
             initial = {}
         initial.update({'parent': self.parent})
-        super(ThreadedCommentForm, self).__init__(target_object, data=data, initial=initial)
+        super(ThreadedCommentForm, self).__init__(
+            target_object, data=data, initial=initial)
 
     def get_comment_model(self):
         return ThreadedComment
@@ -27,4 +28,3 @@ class ThreadedCommentForm(CommentForm):
         d['parent_id'] = self.cleaned_data['parent']
         d['title'] = self.cleaned_data['title']
         return d
-


### PR DESCRIPTION
There are some errors were on django 1.7 version (Tested on example project):

<pre>
ImportError at /message/1
No module named defaults
Request Method:	GET
Request URL:	http://127.0.0.1:8000/message/1
Django Version:	1.7
Exception Type:	ImportError
Exception Value:	
No module named defaults
Exception Location:	/home/stas/workspace/django-threadedcomments/examples/example/urls.py in <module>, line 1
Python Executable:	/home/stas/workspace/django-threadedcomments/env/bin/python
Python Version:	2.7.5
Python Path:	
['/home/stas/workspace/django-threadedcomments',
 '/home/stas/workspace/django-threadedcomments/examples',
 '/home/stas/workspace/django-threadedcomments/env/lib/python2.7',
 '/home/stas/workspace/django-threadedcomments/env/lib/python2.7/plat-x86_64-linux-gnu',
 '/home/stas/workspace/django-threadedcomments/env/lib/python2.7/lib-tk',
 '/home/stas/workspace/django-threadedcomments/env/lib/python2.7/lib-old',
 '/home/stas/workspace/django-threadedcomments/env/lib/python2.7/lib-dynload',
 '/usr/lib/python2.7',
 '/usr/lib/python2.7/plat-x86_64-linux-gnu',
 '/usr/lib/python2.7/lib-tk',
 '/home/stas/workspace/django-threadedcomments/env/local/lib/python2.7/site-packages',
 '/home/stas/workspace/django-threadedcomments/env/lib/python2.7/site-packages']
Server time:	Thu, 11 Sep 2014 00:55:55 -0500
</pre>

<pre>
AttributeError at /message/1
'OrderedDict' object has no attribute 'insert'
Request Method:	GET
Request URL:	http://127.0.0.1:8000/message/1
Django Version:	1.7
Exception Type:	AttributeError
Exception Value:	
'OrderedDict' object has no attribute 'insert'
Exception Location:	/home/stas/workspace/django-threadedcomments/threadedcomments/forms.py in __init__, line 12
Python Executable:	/home/stas/workspace/django-threadedcomments/env/bin/python
Python Version:	2.7.5
Python Path:	
['/home/stas/workspace/django-threadedcomments',
 '/home/stas/workspace/django-threadedcomments/examples',
 '/home/stas/workspace/django-threadedcomments/env/lib/python2.7',
 '/home/stas/workspace/django-threadedcomments/env/lib/python2.7/plat-x86_64-linux-gnu',
 '/home/stas/workspace/django-threadedcomments/env/lib/python2.7/lib-tk',
 '/home/stas/workspace/django-threadedcomments/env/lib/python2.7/lib-old',
 '/home/stas/workspace/django-threadedcomments/env/lib/python2.7/lib-dynload',
 '/usr/lib/python2.7',
 '/usr/lib/python2.7/plat-x86_64-linux-gnu',
 '/usr/lib/python2.7/lib-tk',
 '/home/stas/workspace/django-threadedcomments/env/local/lib/python2.7/site-packages',
 '/home/stas/workspace/django-threadedcomments/env/lib/python2.7/site-packages']
Server time:	Thu, 11 Sep 2014 00:56:55 -0500
</pre>

Changed:

- `django.conf.urls.defaults` replaced to `django.conf.urls`
- In class ThreadedCommentForm: Now `self.base_fields` is `OrderedDict` and hasn't method `insert`

These changes also compatible with django >=1.5